### PR TITLE
Feature/agnostic di service locator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,40 +6,86 @@ It also gives back return values on closure helping the developer catch user act
 
 ## Getting Started
 
-1. Add below builder code in MaterialApp() in main.dart page [sample](https://github.com/1SouravGhosh/flutter_inline_dialogs/blob/master/example/sample_app.dart/)
+1. Firstly add `inline_dialogs` as a dependency:
 
-<pre>
-<code class='language-dart hljs'>
- builder: (context, widget) => Navigator(
-        onGenerateRoute: (settings) => MaterialPageRoute(
-            builder: (context) => DialogManager(
-                  child: widget,
-                )),
-      ),
+```yml
+dependencies:
+  flutter:
+    sdk: flutter
+  inline_dialogs:
+```
 
-</code>
-</pre>
+2. The package consists of `DialogManager` and `DialogService`, with `DialogService` passed as a constructor argument to `DialogManager`. This can be achieved via dependency injection (i.e. *Provider*) or a service locator (i.e. *get_it*).
 
-2. Add dialogSetupLocator in main() in main.dart page [sample](https://github.com/1SouravGhosh/flutter_inline_dialogs/blob/master/example/sample_app.dart/)
+### *get_it*
 
-<pre>
-<code class='language-dart hljs'>
- void main() {
+Firstly register `DialogService` as a singleton
+
+```dart
+import 'package:get_it/get_it.dart';
+import 'package:inline_dialogs/dialogs/service.dart';
+
+GetIt locator = GetIt.instance;
+
+void dialogSetupLocator() {
+  locator.registerSingleton(DialogService());
+}
+```
+
+```dart
+void main() {
   dialogSetupLocator();
   runApp(MyApp());
 }
+```
 
-</code>
-</pre>
+then add `DialogManager` to MaterialApp's builder method
 
-That's it! You are good to go. 
+```dart
+MaterialApp(
+  builder: (context, widget) => Navigator(
+    onGenerateRoute: (settings) => MaterialPageRoute(
+      builder: (context) => DialogManager(
+        dialogService: locator<DialogService>(),
+        child: widget,
+      ),
+    ),
+  ),
+),
+```
+
+### *provider*
+
+Firstly register `DialogService` for DI
+
+```dart
+Provider<DialogService>(
+  create: (context) => DialogService(),
+)
+```
+
+then add `DialogManager` to MaterialApp's builder method
+
+```dart
+MaterialApp(
+  builder: (context, widget) => Navigator(
+    onGenerateRoute: (settings) => MaterialPageRoute(
+      builder: (context) => DialogManager(
+        dialogService: Provider.of<DialogService>(context),
+        child: widget,
+      ),
+    ),
+  ),
+),
+```
+
+3. That's it! You are good to go.
 
 ## Demo
-<p><img src='https://raw.githubusercontent.com/1SouravGhosh/flutter_inline_dialogs/master/assets/explainer.gif' style='width: 30vw; min-width: 30px;' alt='Inline dialog demo'/>
-</p>
 
-# Implementation
+<p><img src='https://raw.githubusercontent.com/1SouravGhosh/flutter_inline_dialogs/master/assets/explainer.gif' style='width: 30vw; min-width: 30px;' alt='Inline dialog demo'/></p>
 
+## Implementation
 
 1. Implement option dialog  [ dialogType: DialogType.option ]
 <pre>
@@ -131,6 +177,3 @@ A special shout out to FilledStacks YouTube channel. Please show some love and s
 For help getting started with Flutter, view our 
 [github repo](https://github.com/1SouravGhosh/flutter_inline_dialogs/), which offers tutorials, 
 samples, guidance on mobile development, and a full API reference.
-
-
-

--- a/example/sample_app.dart
+++ b/example/sample_app.dart
@@ -2,10 +2,16 @@ import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:inline_dialogs/custom_utils/service_locator.dart';
+import 'package:get_it/get_it.dart';
 import 'package:inline_dialogs/dialogs/manager.dart';
 import 'package:inline_dialogs/dialogs/model.dart';
 import 'package:inline_dialogs/dialogs/service.dart';
+
+GetIt locator = GetIt.instance;
+
+void dialogSetupLocator() {
+  locator.registerSingleton(DialogService());
+}
 
 void main() {
   dialogSetupLocator();
@@ -20,9 +26,11 @@ class MyApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       builder: (context, widget) => Navigator(
         onGenerateRoute: (settings) => MaterialPageRoute(
-            builder: (context) => DialogManager(
-                  child: widget,
-                )),
+          builder: (context) => DialogManager(
+            dialogService: locator<DialogService>(),
+            child: widget,
+          ),
+        ),
       ),
       theme: ThemeData(
         primarySwatch: Colors.blue,

--- a/lib/custom_utils/service_locator.dart
+++ b/lib/custom_utils/service_locator.dart
@@ -1,8 +1,0 @@
-import 'package:get_it/get_it.dart';
-import 'package:inline_dialogs/dialogs/service.dart';
-
-GetIt locator = GetIt.instance;
-
-void dialogSetupLocator() {
-  locator.registerSingleton(DialogService());
-}

--- a/lib/dialogs/manager.dart
+++ b/lib/dialogs/manager.dart
@@ -1,23 +1,29 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:inline_dialogs/custom_utils/service_locator.dart';
-import 'package:inline_dialogs/dialogs/model.dart';
-import 'package:inline_dialogs/dialogs/service.dart';
+
+import 'model.dart';
+import 'service.dart';
 
 class DialogManager extends StatefulWidget {
+  final DialogService dialogService;
   final Widget child;
-  DialogManager({Key key, this.child}) : super(key: key);
+
+  DialogManager({
+    Key key,
+    @required this.dialogService,
+    @required this.child,
+  })  : assert(dialogService != null),
+        assert(child != null),
+        super(key: key);
 
   _DialogManagerState createState() => _DialogManagerState();
 }
 
 class _DialogManagerState extends State<DialogManager> {
-  DialogService _dialogService = locator<DialogService>();
-
   @override
   void initState() {
     super.initState();
-    _dialogService.registerDialogListener(_showDialog, _dismissDialog);
+    widget.dialogService.registerDialogListener(_showDialog, _dismissDialog);
   }
 
   @override
@@ -44,11 +50,12 @@ class _DialogManagerState extends State<DialogManager> {
             ));
   }
 
-  List<CupertinoDialogAction> _buildButton(
-      {DialogType dialogType,
-      String optionLeft,
-      String optionRight,
-      String buttonText}) {
+  List<CupertinoDialogAction> _buildButton({
+    DialogType dialogType,
+    String optionLeft,
+    String optionRight,
+    String buttonText,
+  }) {
     switch (dialogType) {
       case DialogType.option:
         {
@@ -59,7 +66,7 @@ class _DialogManagerState extends State<DialogManager> {
                 style: TextStyle(color: Colors.blueAccent),
               ),
               onPressed: () {
-                _dialogService.dialogComplete(
+                widget.dialogService.dialogComplete(
                     DialogResponse(optionLeft: optionLeft, confirmed: true));
                 Navigator.of(context).pop();
               },
@@ -70,7 +77,7 @@ class _DialogManagerState extends State<DialogManager> {
                 style: TextStyle(color: Colors.red),
               ),
               onPressed: () {
-                _dialogService.dialogComplete(
+                widget.dialogService.dialogComplete(
                     DialogResponse(optionRight: optionRight, confirmed: true));
                 Navigator.of(context).pop();
               },
@@ -90,7 +97,7 @@ class _DialogManagerState extends State<DialogManager> {
                 ),
               ),
               onPressed: () {
-                _dialogService.dialogComplete(
+                widget.dialogService.dialogComplete(
                     DialogResponse(optionLeft: buttonText, confirmed: true));
                 Navigator.of(context).pop();
               },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "2.0.10"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.5.2"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.3.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.0.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.14.11"
   convert:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -67,34 +67,27 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  get_it:
-    dependency: "direct main"
-    description:
-      name: get_it
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.0.2"
   image:
     dependency: transitive
     description:
       name: image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.12"
+    version: "2.1.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.1.7"
   path:
     dependency: transitive
     description:
@@ -102,6 +95,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.8.0+1"
   petitparser:
     dependency: transitive
     description:
@@ -115,7 +115,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -127,7 +127,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.5.5"
   stack_trace:
     dependency: transitive
     description:
@@ -162,7 +162,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.5"
   typed_data:
     dependency: transitive
     description:
@@ -183,6 +183,6 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.6.1"
+    version: "3.5.0"
 sdks:
   dart: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,8 @@ name: inline_dialogs
 description: A simple Flutter package to implement inline dialogs which can be managed from the main program context. The dialog can be closed from the same code from which it was invoked.
 version: 1.0.1
 homepage: https://github.com/1SouravGhosh/flutter_inline_dialogs
+repository: https://github.com/1SouravGhosh/flutter_inline_dialogs
+issue_tracker: https://github.com/1SouravGhosh/flutter_inline_dialogs/issues
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -16,39 +18,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,8 +12,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-  get_it: ^4.0.2
-
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Thanks @1SouravGhosh for creating this package. I remember reading @FilledStacks's article last year and felt that such a solution would be very useful indeed.

Presently GetIt is used to resolve `DialogManager`'s dependency on `DialogService`. This PR enables `inline_dialogs` to be agnostic about the method in which this dependency is resolved, i.e. DI like _provider_ or a service locator like _get_it_

README has been updated with examples using _get_it_ and _provider_.